### PR TITLE
Fix signed request path should include query parameters

### DIFF
--- a/open-banking-driver-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/open-banking-driver-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1196,6 +1196,10 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     mandatoryHeaders.put("Digest", digest(body == null ? "" : body.toString()));
     mandatoryHeaders.put("Date", ZonedDateTime.now(ZoneId.of("GMT")).format(FORMATTER));
 
+    if (!queryParams.isEmpty()) {
+        path = target.getUri().getRawPath() + "?" + target.getUri().getRawQuery();
+    }
+
     String signature = sign(signer, method.toLowerCase(), path, mandatoryHeaders).toString();
 
     if (!headerParams.containsKey("Authorization")) mandatoryHeaders.put("Authorization", "Bearer " + applicationAccessToken);


### PR DESCRIPTION
Client reported that they couldn't make requests when using endpoints which take in query parameters like this one [/v3/accounts/{account-id}/transactions](https://developer.ing.com/api-marketplace/marketplace/b6d5093d-626e-41e9-b9e8-ff287bbe2c07/reference?endpoint=2).

The solution is to include those query parameters, if they exists, in the path that gets included in the signing string.